### PR TITLE
Feature manage subscriber in pingreq

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -150,11 +150,6 @@ type ClientState struct {
 	outboundQty     int32                // number of messages currently in the outbound queue
 	Keepalive       uint16               // the number of seconds the connection can wait
 	ServerKeepalive bool                 // keepalive was set by the server
-	Selector        Selector
-}
-
-type Selector struct {
-	CanSend bool `json:"canSend"`
 }
 
 // newClient returns a new instance of Client. This is almost exclusively used by Server
@@ -170,7 +165,6 @@ func newClient(c net.Conn, o *ops) *Client {
 			cancelOpen:    cancel,
 			Keepalive:     defaultKeepalive,
 			outbound:      make(chan *packets.Packet, o.options.Capabilities.MaximumClientWritesPending),
-			Selector:      Selector{CanSend: true},
 		},
 		Properties: ClientProperties{
 			ProtocolVersion: defaultClientProtocolVersion, // default protocol version

--- a/examples/hooks/onselect/main.go
+++ b/examples/hooks/onselect/main.go
@@ -98,12 +98,13 @@ func (h *SelectHook) OnSelectSubscribers(s *mqtt.Subscribers, pk packets.Packet)
 		// extract subscribers which can be sent
 		clients := make([]string, 0)
 		subs := make([]packets.Subscription, 0)
-		for clientId, sub := range shared {
-			clt, ok := h.server.Clients.Get(clientId)
-			if ok && clt.State.Selector.CanSend {
-				clients = append(clients, clientId)
-				subs = append(subs, sub)
-			}
+		for _, sub := range shared {
+			//clt, ok := h.server.Clients.Get(clientId)
+			//if ok && clt.State.Selector.CanSend {
+			//	clients = append(clients, clientId)
+			//	subs = append(subs, sub)
+			//}
+			subs = append(subs, sub)
 		}
 		// Select one subscriber in subscribers which can be sent. If no subscriber can be sent,
 		// one is randomly selected from the group.

--- a/examples/hooks/sharedsub/main.go
+++ b/examples/hooks/sharedsub/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/mochi-co/mqtt/v2"
+	"github.com/mochi-co/mqtt/v2/hooks/auth"
+	"github.com/mochi-co/mqtt/v2/hooks/sharedsub"
+	"github.com/mochi-co/mqtt/v2/listeners"
+	"github.com/rs/zerolog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	tcpAddr := ":1883"
+	infoAddr := ":8080"
+
+	// When signal is notified shut down server
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		done <- true
+	}()
+
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel).Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	opts := new(mqtt.Options)
+	opts.Logger = &log
+	server := mqtt.New(opts)
+	_ = server.AddHook(new(auth.AllowHook), nil)
+
+	manager := sharedsub.NewManager(&log)
+	hook := sharedsub.NewHook(manager)
+	_ = server.AddHook(hook, nil)
+
+	tcp := listeners.NewTCP("t1", tcpAddr, nil)
+	err := server.AddListener(tcp)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create TCP listener")
+		return
+	}
+
+	stats := listeners.NewHTTPStats("stats", infoAddr, nil, server.Info)
+	err = server.AddListener(stats)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create HTTP status listener")
+		return
+	}
+
+	go func() {
+		err := server.Serve()
+		if err != nil {
+			log.Error().Err(err).Msg("an error occurred on the server")
+		}
+	}()
+
+	<-done
+	server.Log.Warn().Msg("caught signal, stopping...")
+	server.Close()
+	server.Log.Info().Msg("main.go finished")
+}

--- a/hooks/sharedsub/hook.go
+++ b/hooks/sharedsub/hook.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"github.com/mochi-co/mqtt/v2"
 	"github.com/mochi-co/mqtt/v2/packets"
-	"github.com/rs/zerolog"
 )
 
 type Hook struct {
 	manager Manager
-	Log     *zerolog.Logger
 	mqtt.HookBase
 }
 
@@ -51,7 +49,6 @@ func (h *Hook) OnSelectSubscribers(subs *mqtt.Subscribers, pk packets.Packet) *m
 		selClientId, err := h.manager.SelectSubscriber(topicFilter, groupSubs, pk)
 
 		if err != nil {
-			h.Log.Error().Err(err).Str("topic", topicFilter).Msg("An error occurred during subscriber selection.")
 			// Use standard function implemented by server.
 			subs.SharedSelected = map[string]packets.Subscription{}
 			return subs

--- a/hooks/sharedsub/hook.go
+++ b/hooks/sharedsub/hook.go
@@ -11,6 +11,12 @@ type Hook struct {
 	mqtt.HookBase
 }
 
+func NewHook(manager Manager) *Hook {
+	return &Hook{
+		manager: manager,
+	}
+}
+
 func (h *Hook) ID() string {
 	return "pingreq-hook"
 }

--- a/hooks/sharedsub/hook.go
+++ b/hooks/sharedsub/hook.go
@@ -1,0 +1,70 @@
+package sharedsub
+
+import (
+	"bytes"
+	"github.com/mochi-co/mqtt/v2"
+	"github.com/mochi-co/mqtt/v2/packets"
+	"github.com/rs/zerolog"
+)
+
+type Hook struct {
+	manager Manager
+	Log     *zerolog.Logger
+	mqtt.HookBase
+}
+
+func (h *Hook) ID() string {
+	return "pingreq-hook"
+}
+
+func (h *Hook) Provides(b byte) bool {
+	return bytes.Contains([]byte{
+		mqtt.OnSessionEstablished,
+		mqtt.OnPacketRead,
+		mqtt.OnSelectSubscribers,
+		mqtt.OnDisconnect,
+	}, []byte{b})
+}
+
+func (h *Hook) OnSessionEstablished(cl *mqtt.Client, pk packets.Packet) {
+	h.manager.UpdateClient(cl)
+}
+
+func (h *Hook) OnPacketRead(cl *mqtt.Client, pk packets.Packet) (packets.Packet, error) {
+	if pk.FixedHeader.Type == packets.Pingreq && pk.Payload != nil {
+		err := h.manager.UpdateClientInfo(cl, pk)
+		if err != nil {
+			return pk, err
+		}
+	}
+	return pk, nil
+}
+
+func (h *Hook) OnDisconnect(cl *mqtt.Client, err error, expire bool) {
+	h.manager.DeleteClient(cl)
+}
+
+func (h *Hook) OnSelectSubscribers(subs *mqtt.Subscribers, pk packets.Packet) *mqtt.Subscribers {
+	subs.SharedSelected = map[string]packets.Subscription{} // clientID and Subscription of the client.
+	for topicFilter, groupSubs := range subs.Shared {
+		// Select subscriber with information retained by the manager.
+		selClientId, err := h.manager.SelectSubscriber(topicFilter, groupSubs, pk)
+
+		if err != nil {
+			h.Log.Error().Err(err).Str("topic", topicFilter).Msg("An error occurred during subscriber selection.")
+			// Use standard function implemented by server.
+			subs.SharedSelected = map[string]packets.Subscription{}
+			return subs
+		}
+
+		// Update subscription.
+		// If the same subscriber is matched, the QoS delivered to the subscriber is adjusted to the value
+		// of the largest QoS among the matched topics.
+		oldSub, ok := subs.SharedSelected[selClientId]
+		if !ok {
+			oldSub = groupSubs[selClientId]
+		}
+		subs.SharedSelected[selClientId] = oldSub.Merge(groupSubs[selClientId])
+	}
+	return subs
+}

--- a/hooks/sharedsub/hook_test.go
+++ b/hooks/sharedsub/hook_test.go
@@ -1,0 +1,212 @@
+package sharedsub
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mochi-co/mqtt/v2"
+	"github.com/mochi-co/mqtt/v2/packets"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+type MockManager struct {
+	Clients map[string]bool
+}
+
+func (m *MockManager) UpdateClient(cl *mqtt.Client) {
+	m.Clients[cl.ID] = true
+}
+
+func (m *MockManager) DeleteClient(cl *mqtt.Client) {
+}
+
+func (m *MockManager) UpdateClientInfo(cl *mqtt.Client, pk packets.Packet) error {
+	if pk.FixedHeader.Type == packets.Pingreq && pk.Payload != nil {
+		m.Clients[cl.ID] = true
+		return nil
+	}
+	return errors.New("invalid packet type")
+}
+
+func (m *MockManager) SelectSubscriber(topicFilter string, groupSubs map[string]packets.Subscription, pk packets.Packet) (string, error) {
+	for clientId, _ := range groupSubs {
+		if m.Clients[clientId] {
+			return clientId, nil
+		}
+	}
+	return "", errors.New(fmt.Sprintf("client not found: %s", topicFilter))
+}
+
+func TestID(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "test Hook ID", want: "pingreq-hook"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := new(Hook)
+			require.Equal(t, tt.want, h.ID())
+			if got := h.ID(); got != tt.want {
+				t.Errorf("ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProvides(t *testing.T) {
+	type args struct {
+		b byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{name: "OnSessionEstablished", args: args{b: mqtt.OnSessionEstablished}, want: true},
+		{name: "OnPacketRead", args: args{b: mqtt.OnSessionEstablished}, want: true},
+		{name: "OnSelectSubscribers", args: args{b: mqtt.OnSessionEstablished}, want: true},
+		{name: "OnDisconnect", args: args{b: mqtt.OnSessionEstablished}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Hook{}
+			require.Equal(t, tt.want, h.Provides(tt.args.b))
+		})
+	}
+}
+
+func TestOnPacketRead(t *testing.T) {
+	type fields struct {
+		manager Manager
+	}
+	type args struct {
+		cl *mqtt.Client
+		pk packets.Packet
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   error
+		wantCl bool
+	}{
+		{
+			name: "receive extended pingreq",
+			fields: fields{manager: &MockManager{
+				Clients: make(map[string]bool),
+			}},
+			args: args{
+				cl: &mqtt.Client{ID: "ok-client"},
+				pk: packets.Packet{
+					FixedHeader: packets.FixedHeader{Type: packets.Pingreq},
+					Payload:     []byte("Hello World"),
+				},
+			},
+			want:   nil,
+			wantCl: true,
+		},
+		{
+			name: "receive standard pingreq",
+			fields: fields{manager: &MockManager{
+				Clients: make(map[string]bool),
+			}},
+			args: args{
+				cl: &mqtt.Client{ID: "ok-client"},
+				pk: packets.Packet{
+					FixedHeader: packets.FixedHeader{Type: packets.Pingreq},
+				},
+			},
+			want:   nil,
+			wantCl: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Hook{
+				manager: tt.fields.manager,
+			}
+			_, err := h.OnPacketRead(tt.args.cl, tt.args.pk)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCl, tt.fields.manager.(*MockManager).Clients[tt.args.cl.ID])
+		})
+	}
+}
+
+func TestOnSelectSubscribers(t *testing.T) {
+	type fields struct {
+		manager Manager
+	}
+	type client struct {
+		ID  string
+		sel bool
+	}
+	type args struct {
+		subs *mqtt.Subscribers
+		cls  []client
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *mqtt.Subscribers
+	}{
+		{
+			name: "select subscriber",
+			fields: fields{manager: &MockManager{
+				Clients: make(map[string]bool),
+			}},
+			args: args{
+				subs: &mqtt.Subscribers{
+					Shared: map[string]map[string]packets.Subscription{
+						"$share/g/t1": {
+							"client-1": packets.Subscription{},
+							"client-2": packets.Subscription{},
+							"client-3": packets.Subscription{},
+						},
+					},
+					SharedSelected: nil,
+					Subscriptions:  nil,
+				},
+				cls: []client{
+					{ID: "client-1", sel: false},
+					{ID: "client-2", sel: true},
+					{ID: "client-3", sel: false},
+				},
+			},
+			want: &mqtt.Subscribers{
+				Shared: map[string]map[string]packets.Subscription{
+					"$share/g/t1": {
+						"client-1": packets.Subscription{},
+						"client-2": packets.Subscription{},
+						"client-3": packets.Subscription{},
+					},
+				},
+				SharedSelected: map[string]packets.Subscription{
+					"client-2": {
+						Identifiers: map[string]int{
+							"": 0,
+						},
+					},
+				},
+				Subscriptions: nil,
+			},
+		},
+	}
+	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel).Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Hook{
+				manager: tt.fields.manager,
+				Log:     &log,
+			}
+			for _, cl := range tt.args.cls {
+				h.manager.(*MockManager).Clients[cl.ID] = cl.sel
+			}
+			require.Equal(t, tt.want, h.OnSelectSubscribers(tt.args.subs, packets.Packet{}))
+		})
+	}
+}

--- a/hooks/sharedsub/hook_test.go
+++ b/hooks/sharedsub/hook_test.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"github.com/mochi-co/mqtt/v2"
 	"github.com/mochi-co/mqtt/v2/packets"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"os"
 	"testing"
 )
 
@@ -196,12 +194,10 @@ func TestOnSelectSubscribers(t *testing.T) {
 			},
 		},
 	}
-	log := zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.InfoLevel).Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &Hook{
 				manager: tt.fields.manager,
-				Log:     &log,
 			}
 			for _, cl := range tt.args.cls {
 				h.manager.(*MockManager).Clients[cl.ID] = cl.sel

--- a/hooks/sharedsub/manager.go
+++ b/hooks/sharedsub/manager.go
@@ -1,0 +1,138 @@
+package sharedsub
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/mochi-co/mqtt/v2"
+	"github.com/mochi-co/mqtt/v2/packets"
+	"math"
+	"sync"
+)
+
+// Manager manage information received from pingreq.
+type Manager interface {
+	UpdateClient(cl *mqtt.Client)
+	UpdateClientInfo(cl *mqtt.Client, pk packets.Packet) error
+	DeleteClient(cl *mqtt.Client)
+	SelectSubscriber(topicFilter string, groupSubs map[string]packets.Subscription, pk packets.Packet) (string, error)
+}
+
+const (
+	defaultRetainedSize = 100
+)
+
+// The StatusManager maintains the number of messages in the queue and the processing time per message for each client.
+type StatusManager struct {
+	sync.RWMutex
+	clients map[string]*Client
+}
+
+// Payload is message format of pingreq sent by client.
+type Payload struct {
+	NumberOfMsgsInQueue  int     `json:"numberOfMsgsInQueue"`
+	ProcessingTimePerMsg float64 `json:"processingTimerPerMsg"`
+}
+
+type Client struct {
+	sync.RWMutex
+	receivedPayload         []Payload
+	avgNumberOfMsgsInQueue  float64
+	avgProcessingTimePerMsg float64
+	sentMessageCount        int32
+}
+
+func NewManager() *StatusManager {
+	sm := &StatusManager{
+		clients: make(map[string]*Client),
+	}
+	return sm
+}
+
+func NewClient() *Client {
+	return &Client{
+		receivedPayload:         make([]Payload, 0, defaultRetainedSize),
+		avgNumberOfMsgsInQueue:  0,
+		avgProcessingTimePerMsg: 0,
+	}
+}
+
+func (m *StatusManager) UpdateClient(cl *mqtt.Client) {
+	m.Lock()
+	defer m.Unlock()
+	m.clients[cl.ID] = NewClient()
+}
+
+func (m *StatusManager) DeleteClient(cl *mqtt.Client) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.clients, cl.ID)
+}
+
+func (m *StatusManager) UpdateClientInfo(cl *mqtt.Client, pk packets.Packet) error {
+	client, ok := m.clients[cl.ID]
+	if !ok {
+		return errors.New("client is not found")
+	}
+	client.Lock()
+	defer client.Unlock()
+
+	p := Payload{}
+	err := json.Unmarshal(pk.Payload, &p)
+	if err != nil {
+		return err
+	}
+
+	// Update value using subscriber selection with pingreq.
+	totalMsgInQueue := client.avgNumberOfMsgsInQueue * float64(len(client.receivedPayload))
+	totalProcessingTime := client.avgProcessingTimePerMsg * float64(len(client.receivedPayload))
+	if len(client.receivedPayload) == defaultRetainedSize {
+		// Remove old information.
+		totalProcessingTime -= client.receivedPayload[0].ProcessingTimePerMsg
+		totalMsgInQueue -= float64(client.receivedPayload[0].NumberOfMsgsInQueue)
+		client.receivedPayload = client.receivedPayload[1:]
+	}
+	client.receivedPayload = append(client.receivedPayload, p)
+	client.avgNumberOfMsgsInQueue = (totalMsgInQueue + float64(p.NumberOfMsgsInQueue)) / float64(len(client.receivedPayload))
+	client.avgProcessingTimePerMsg = (totalProcessingTime + p.ProcessingTimePerMsg) / float64(len(client.receivedPayload))
+	client.sentMessageCount = 0
+	return nil
+}
+
+func (m *StatusManager) SelectSubscriber(
+	topicFilter string,
+	groupSubs map[string]packets.Subscription,
+	pk packets.Packet,
+) (string, error) {
+	var selectedClientId string
+	minMsgsInQueue := math.MaxFloat64
+	minProcessingTime := math.MaxFloat64
+
+	for clientId, _ := range groupSubs {
+		cl, ok := m.clients[clientId]
+		if !ok {
+			continue
+		}
+		cl.RLock()
+		numMsgsInQueue := cl.avgNumberOfMsgsInQueue + float64(cl.sentMessageCount)
+		processingTime := cl.avgProcessingTimePerMsg
+		cl.RUnlock()
+
+		if numMsgsInQueue < minMsgsInQueue || (numMsgsInQueue == minMsgsInQueue && processingTime < minProcessingTime) {
+			selectedClientId = clientId
+			minMsgsInQueue = numMsgsInQueue
+			minProcessingTime = processingTime
+		}
+	}
+
+	if selectedClientId == "" {
+		return "", errors.New(fmt.Sprintf("client not found: %s", topicFilter))
+	}
+
+	cl := m.clients[selectedClientId]
+	cl.Lock()
+	cl.sentMessageCount++
+	cl.Unlock()
+
+	return selectedClientId, nil
+}

--- a/hooks/sharedsub/manager_test.go
+++ b/hooks/sharedsub/manager_test.go
@@ -4,13 +4,17 @@ import (
 	"fmt"
 	"github.com/mochi-co/mqtt/v2"
 	"github.com/mochi-co/mqtt/v2/packets"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"math"
+	"os"
 	"testing"
 )
 
+var logger = zerolog.New(os.Stderr).With().Timestamp().Logger().Level(zerolog.Disabled)
+
 func TestUpdateClient(t *testing.T) {
-	sm := NewManager()
+	sm := NewManager(&logger)
 	cl := &mqtt.Client{
 		ID: "test-client",
 	}
@@ -20,7 +24,7 @@ func TestUpdateClient(t *testing.T) {
 }
 
 func TestDeleteClient(t *testing.T) {
-	sm := NewManager()
+	sm := NewManager(&logger)
 	cl := &mqtt.Client{
 		ID: "test-client",
 	}
@@ -33,7 +37,7 @@ func TestDeleteClient(t *testing.T) {
 }
 
 func TestUpdateClientInfoValid(t *testing.T) {
-	sm := NewManager()
+	sm := NewManager(&logger)
 
 	cl := &mqtt.Client{
 		ID: "two-message",
@@ -74,7 +78,7 @@ func TestUpdateClientInfoValid(t *testing.T) {
 }
 
 func TestUpdateClientInfoInvalid(t *testing.T) {
-	sm := NewManager()
+	sm := NewManager(&logger)
 
 	cl := &mqtt.Client{
 		ID: "valid-client",
@@ -121,7 +125,7 @@ func TestSelectSubscriber(t *testing.T) {
 		"client-3": {},
 	}
 
-	sm := NewManager()
+	sm := NewManager(&logger)
 	for _, s := range subs {
 		sm.UpdateClient(s.cl)
 		err := sm.UpdateClientInfo(s.cl, s.pk)
@@ -157,7 +161,7 @@ func TestSubscriberNotUpdate(t *testing.T) {
 		"client-3": {},
 	}
 
-	sm := NewManager()
+	sm := NewManager(&logger)
 	for _, s := range subs {
 		sm.UpdateClient(s.cl)
 	}

--- a/hooks/sharedsub/manager_test.go
+++ b/hooks/sharedsub/manager_test.go
@@ -136,6 +136,48 @@ func TestSelectSubscriber(t *testing.T) {
 	require.Equal(t, "client-2", got)
 }
 
+func TestSubscriberNotUpdate(t *testing.T) {
+	type sub struct {
+		cl *mqtt.Client
+	}
+	subs := []sub{
+		{
+			cl: &mqtt.Client{ID: "client-1"},
+		},
+		{
+			cl: &mqtt.Client{ID: "client-2"},
+		},
+		{
+			cl: &mqtt.Client{ID: "client-3"},
+		},
+	}
+	groupSubs := map[string]packets.Subscription{
+		"client-1": {},
+		"client-2": {},
+		"client-3": {},
+	}
+
+	sm := NewManager()
+	for _, s := range subs {
+		sm.UpdateClient(s.cl)
+	}
+	got, err := sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	t.Log(got)
+
+	got, err = sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	t.Log(got)
+
+	got, err = sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	t.Log(got)
+
+	got, err = sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	t.Log(got)
+}
+
 func createPingreq(t *testing.T, inQueue int, perMessage float64) packets.Packet {
 	t.Helper()
 	pk := packets.Packet{

--- a/hooks/sharedsub/manager_test.go
+++ b/hooks/sharedsub/manager_test.go
@@ -1,0 +1,155 @@
+package sharedsub
+
+import (
+	"fmt"
+	"github.com/mochi-co/mqtt/v2"
+	"github.com/mochi-co/mqtt/v2/packets"
+	"github.com/stretchr/testify/require"
+	"math"
+	"testing"
+)
+
+func TestUpdateClient(t *testing.T) {
+	sm := NewManager()
+	cl := &mqtt.Client{
+		ID: "test-client",
+	}
+	sm.UpdateClient(cl)
+	_, ok := sm.clients[cl.ID]
+	require.True(t, ok)
+}
+
+func TestDeleteClient(t *testing.T) {
+	sm := NewManager()
+	cl := &mqtt.Client{
+		ID: "test-client",
+	}
+	sm.UpdateClient(cl)
+	_, ok := sm.clients[cl.ID]
+	require.True(t, ok)
+	sm.DeleteClient(cl)
+	_, ok = sm.clients[cl.ID]
+	require.False(t, ok)
+}
+
+func TestUpdateClientInfoValid(t *testing.T) {
+	sm := NewManager()
+
+	cl := &mqtt.Client{
+		ID: "two-message",
+	}
+	sm.UpdateClient(cl)
+
+	// Receive two pingreq
+	pk := createPingreq(t, 1, 0.1)
+	err := sm.UpdateClientInfo(cl, pk)
+	require.NoError(t, err)
+	require.True(t, math.Abs(sm.clients[cl.ID].avgNumberOfMsgsInQueue-1.0) < 0.00001)
+	require.True(t, math.Abs(sm.clients[cl.ID].avgProcessingTimePerMsg-0.1) < 0.00001)
+	pk = createPingreq(t, 3, 0.3)
+	err = sm.UpdateClientInfo(cl, pk)
+	require.NoError(t, err)
+	require.True(t, math.Abs(sm.clients[cl.ID].avgNumberOfMsgsInQueue-2.0) < 0.00001)
+	require.True(t, math.Abs(sm.clients[cl.ID].avgProcessingTimePerMsg-0.2) < 0.00001)
+
+	// Receive pingreq larger than defaultRetainSize
+	cl = &mqtt.Client{
+		ID: "over-message",
+	}
+	sm.UpdateClient(cl)
+	overSize := 5
+	for i := 1; i <= defaultRetainedSize+overSize; i++ {
+		err = sm.UpdateClientInfo(cl, createPingreq(t, i, float64(i)*0.1))
+		require.NoError(t, err)
+	}
+	var sumAvgNumberOfMsgsInQueue, sumAvgProcessingTimePerMsg float64
+	for i := 1 + overSize; i <= defaultRetainedSize+overSize; i++ {
+		sumAvgNumberOfMsgsInQueue += float64(i)
+		sumAvgProcessingTimePerMsg += float64(i) * 0.1
+	}
+	want := sumAvgNumberOfMsgsInQueue / defaultRetainedSize
+	require.True(t, math.Abs(sm.clients[cl.ID].avgNumberOfMsgsInQueue-want) < 0.000001)
+	want = sumAvgProcessingTimePerMsg / defaultRetainedSize
+	require.True(t, math.Abs(sm.clients[cl.ID].avgProcessingTimePerMsg-want) < 0.000001)
+}
+
+func TestUpdateClientInfoInvalid(t *testing.T) {
+	sm := NewManager()
+
+	cl := &mqtt.Client{
+		ID: "valid-client",
+	}
+	sm.UpdateClient(cl)
+
+	// Receive invalid payload
+	pk := createPingreq(t, 1, 0.1)
+	pk.Payload = []byte("Hello World")
+	err := sm.UpdateClientInfo(cl, pk)
+	require.Error(t, err)
+
+	// Non-existent client
+	cl = &mqtt.Client{
+		ID: "invalid-client",
+	}
+	pk = createPingreq(t, 1, 1)
+	err = sm.UpdateClientInfo(cl, pk)
+	require.Error(t, err)
+}
+
+func TestSelectSubscriber(t *testing.T) {
+	type sub struct {
+		cl *mqtt.Client
+		pk packets.Packet
+	}
+	subs := []sub{
+		{
+			cl: &mqtt.Client{ID: "client-1"},
+			pk: createPingreq(t, 1, 2),
+		},
+		{
+			cl: &mqtt.Client{ID: "client-2"},
+			pk: createPingreq(t, 2, 1),
+		},
+		{
+			cl: &mqtt.Client{ID: "client-3"},
+			pk: createPingreq(t, 3, 2),
+		},
+	}
+	groupSubs := map[string]packets.Subscription{
+		"client-1": {},
+		"client-2": {},
+		"client-3": {},
+	}
+
+	sm := NewManager()
+	for _, s := range subs {
+		sm.UpdateClient(s.cl)
+		err := sm.UpdateClientInfo(s.cl, s.pk)
+		require.NoError(t, err)
+	}
+	got, err := sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	require.Equal(t, "client-1", got)
+
+	got, err = sm.SelectSubscriber("", groupSubs, packets.Packet{})
+	require.Equal(t, nil, err)
+	require.Equal(t, "client-2", got)
+}
+
+func createPingreq(t *testing.T, inQueue int, perMessage float64) packets.Packet {
+	t.Helper()
+	pk := packets.Packet{
+		FixedHeader: packets.FixedHeader{
+			Type: packets.Pingreq,
+		},
+		Properties: packets.Properties{
+			User: []packets.UserProperty{
+				{Key: "messageId", Val: "1"},
+			},
+		},
+		Payload: []byte(
+			fmt.Sprintf("{\"numberOfMsgsInQueue\": %d, \"processingTimerPerMsg\":%f}",
+				inQueue, perMessage)),
+	}
+	return pk
+}


### PR DESCRIPTION
* PINGREQを受信するHookを実装
* PINGREQで受信したデータからクライアント情報を管理するManagerを実装
* サブスクライバを選択するアルゴリズムを実装
  * クライアントには直近10個のPINGREQを保持
  * 「最新のキュー内のメッセージ数」+「送信された回数」が最も少ないサブスクライバを選択
  * 同じ場合は「直近10個のPINGREQにある1メッセージあたりの処理時間の平均」が最も小さいサブスクライバを選択
  * 選択されたサブスクライバの「送信された回数」をインクリメント
  * PINGREQ受信時に「送信された回数」を0に初期化